### PR TITLE
fix: use value and xmlEncoded attributes to build ad parameters

### DIFF
--- a/src/vast-client-serializer.js
+++ b/src/vast-client-serializer.js
@@ -372,7 +372,10 @@ export default class VASTClientSerializer {
     return {
       '@skipoffset': this.convertToHHMMSS(creative.skipDelay),
       'Duration': this.convertToHHMMSS(creative.duration),
-      'AdParameters': this.buildAdParameters(creative.adParameters),
+      'AdParameters': this.buildAdParameters(
+        creative.adParameters.value,
+        creative.adParameters.xmlEncoded
+      ),
       'MediaFiles': this.buildMediafiles(
         creative.mediaFiles,
         creative.mezzanine,


### PR DESCRIPTION
Vast-Parser returns adParameter node as an object with value and xmlEncoded attributes.

```
adParameters: {
  value: '{"LR_PUBLISHER_ID":150578,"LR_LAYOUT_SKIN_ID":0,"LR_VIDEO_ID":116694061,"LR_COMPANIONS":"300:250:mc_Middle:mc_Middle:true","LR_DEBUG": 0,"LR_ORDER_ID":268350}',
  xmlEncoded: null
},
```

Putting this object inside CDATA template from xmlbuilder2 returns a serialized adParameters with `[Object]` inside.