### PR TITLE
fix: add optional check to ad parameters

### DIFF
--- a/dist/vast-client-to-xml.js
+++ b/dist/vast-client-to-xml.js
@@ -524,7 +524,7 @@ var VASTClientSerializer = /*#__PURE__*/function () {
       return {
         '@skipoffset': this.convertToHHMMSS(creative.skipDelay),
         'Duration': this.convertToHHMMSS(creative.duration),
-        'AdParameters': this.buildAdParameters(creative.adParameters.value, creative.adParameters.xmlEncoded),
+        'AdParameters': creative.adParameters ? this.buildAdParameters(creative.adParameters.value, creative.adParameters.xmlEncoded) : null,
         'MediaFiles': this.buildMediafiles(creative.mediaFiles, creative.mezzanine, creative.interactiveCreativeFile, creative.closedCaptionFiles),
         'VideoClicks': this.buildVideoClicks(creative.videoClickThroughURLTemplate, creative.videoClickTrackingURLTemplates, creative.videoCustomClickURLTemplates),
         'TrackingEvents': this.buildTrackingEvents(creative.trackingEvents),

--- a/src/vast-client-serializer.js
+++ b/src/vast-client-serializer.js
@@ -372,10 +372,10 @@ export default class VASTClientSerializer {
     return {
       '@skipoffset': this.convertToHHMMSS(creative.skipDelay),
       'Duration': this.convertToHHMMSS(creative.duration),
-      'AdParameters': this.buildAdParameters(
+      'AdParameters': creative.adParameters ? this.buildAdParameters(
         creative.adParameters.value,
         creative.adParameters.xmlEncoded
-      ),
+      ): null,
       'MediaFiles': this.buildMediafiles(
         creative.mediaFiles,
         creative.mezzanine,


### PR DESCRIPTION
Ad Parameters can be null from vast client object