### PR TITLE
fix: use new universalAdIds key (multiple universalAdId)

### DIFF
--- a/dist/vast-client-to-xml.js
+++ b/dist/vast-client-to-xml.js
@@ -439,34 +439,35 @@ var VASTClientSerializer = /*#__PURE__*/function () {
       var _this7 = this;
       return {
         'Creative': creatives.map(function (creative) {
-          return _objectSpread2(_objectSpread2({
+          return _objectSpread2({
             '@id': creative.id,
             '@sequence': creative.sequence,
             '@adId': creative.adId,
             '@apiFramework': creative.apiFramework,
-            'CreativeExtensions': _this7.buildCreativeExtensions(creative.creativeExtensions)
-          }, _this7.buildUniversalAdId(creative.universalAdId)), _this7.buildCreativeByType(creative));
+            'CreativeExtensions': _this7.buildCreativeExtensions(creative.creativeExtensions),
+            'UniversalAdId': _this7.buildUniversalAdId(creative.universalAdIds)
+          }, _this7.buildCreativeByType(creative));
         })
       };
     }
 
     /**
      * Build UniversalAdI node
-     * @param {Object} universalAdId A universalAdId object
-     * @returns {Object} An UniversalAdI node
+     * @param {Array<Object>} universalAdIds A universalAdId object array
+     * @returns {Array<Object> | null} An UniversalAdId node array
      */
   }, {
     key: "buildUniversalAdId",
-    value: function buildUniversalAdId(universalAdId) {
-      if (!universalAdId) {
-        return {};
+    value: function buildUniversalAdId(universalAdIds) {
+      if (!universalAdIds.length) {
+        return null;
       }
-      return {
-        'UniversalAdId': {
-          '@idRegistry': universalAdId.idRegistry,
-          '#': universalAdId.value
-        }
-      };
+      return universalAdIds.map(function (universalAdId) {
+        return {
+          "@idRegistry": universalAdId.idRegistry,
+          "#": universalAdId.value
+        };
+      });
     }
 
     /**

--- a/src/vast-client-serializer.js
+++ b/src/vast-client-serializer.js
@@ -298,7 +298,7 @@ export default class VASTClientSerializer {
           '@adId': creative.adId,
           '@apiFramework': creative.apiFramework,
           'CreativeExtensions': this.buildCreativeExtensions(creative.creativeExtensions),
-          ...this.buildUniversalAdId(creative.universalAdId),
+          'UniversalAdId': this.buildUniversalAdId(creative.universalAdIds),
           ...this.buildCreativeByType(creative)
         }
       }),
@@ -307,20 +307,18 @@ export default class VASTClientSerializer {
 
   /**
    * Build UniversalAdI node
-   * @param {Object} universalAdId A universalAdId object
-   * @returns {Object} An UniversalAdI node
+   * @param {Array<Object>} universalAdIds A universalAdId object array
+   * @returns {Array<Object> | null} An UniversalAdId node array
    */
-  buildUniversalAdId(universalAdId) {
-    if (!universalAdId) {
-      return {}
+  buildUniversalAdId(universalAdIds) {
+    if (!universalAdIds.length) {
+      return null;
     }
 
-    return {
-      'UniversalAdId': {
-        '@idRegistry': universalAdId.idRegistry,
-        '#': universalAdId.value,
-      }
-    }
+    return universalAdIds.map((universalAdId) => ({
+      "@idRegistry": universalAdId.idRegistry,
+      "#": universalAdId.value,
+    }));
   }
 
   /**


### PR DESCRIPTION
Since VAST 4.2, we support multiple universalAdId in VAST.
The vast-client was updated but not the serializer.
This PR brings support to the new key `universalAdIds` from vast parser object.